### PR TITLE
Fix #3: Replace Windows boolean typedef with standard C++ bool

### DIFF
--- a/FuzRoBorkInternals.cpp
+++ b/FuzRoBorkInternals.cpp
@@ -910,7 +910,7 @@ namespace FuzRoBorkNamespace {
 		// remove \t \r, etc
 
 		int idx = 0;
-		boolean par = false;
+		bool par = false;
 
 		string newStr = "";
 		while (idx < str.size()) {
@@ -1380,18 +1380,18 @@ namespace FuzRoBorkNamespace {
 		}
 	}
 
-	boolean isSpeaking() {
+	bool isSpeaking() {
 		if (pVoice == NULL)
-			return FALSE;
+			return false;
 		SPVOICESTATUS   pStatus;
 		pVoice->GetStatus(&pStatus, NULL);
 		if (pStatus.dwRunningState == SPRS_IS_SPEAKING)
-			return TRUE;
+			return true;
 
-		return FALSE;
+		return false;
 	}
-	
-	boolean isXVASpeaking() {
+
+	bool isXVASpeaking() {
 		return playingXVAS;
 	}
 

--- a/FuzRoBorkInternals.h
+++ b/FuzRoBorkInternals.h
@@ -333,7 +333,7 @@ public:
 	string speech;
 };
 
-static boolean actionSpeaking = false;
+static bool actionSpeaking = false;
 
 namespace FuzRoBorkNamespace {
 
@@ -364,8 +364,8 @@ namespace FuzRoBorkNamespace {
 	void startPlayerSpeech(const char* _title);
 	void startNarratorSpeech(const char* text);
 	void speakLoadingScreen(const char* text);
-	boolean isSpeaking();
-	boolean isXVASpeaking();
+	bool isSpeaking();
+	bool isXVASpeaking();
 	void stopSpeaking(void);
 	
 }


### PR DESCRIPTION
## Summary
- Replaced Windows `boolean` typedef with standard C++ `bool`
- Replaced `TRUE`/`FALSE` macros with `true`/`false` keywords

## Changes
**FuzRoBorkInternals.h:**
- `static boolean actionSpeaking` → `static bool actionSpeaking`
- `boolean isSpeaking()` → `bool isSpeaking()` (declaration)
- `boolean isXVASpeaking()` → `bool isXVASpeaking()` (declaration)

**FuzRoBorkInternals.cpp:**
- `boolean par` → `bool par`
- `boolean isSpeaking()` → `bool isSpeaking()` (definition)
- `boolean isXVASpeaking()` → `bool isXVASpeaking()` (definition)
- `return TRUE/FALSE` → `return true/false`

## Testing
- [ ] Build succeeds
- [ ] TTS functions work correctly

Closes #3