### PR TITLE
Fix #5: Change static variable in header to extern declaration

### DIFF
--- a/FuzRoBorkInternals.cpp
+++ b/FuzRoBorkInternals.cpp
@@ -13,6 +13,8 @@ FuzRoBorkINIManager		FuzRoBorkINIManager::Instance;
 SubtitleHasher			SubtitleHasher::Instance;
 const double			SubtitleHasher::kPurgeInterval = 1000.0 * 60.0f;
 
+bool					actionSpeaking = false;
+
 
 SME::INI::INISetting	kWordsPerSecondSilence("WordsPerSecondSilence",
 	"General",

--- a/FuzRoBorkInternals.h
+++ b/FuzRoBorkInternals.h
@@ -333,7 +333,7 @@ public:
 	string speech;
 };
 
-static boolean actionSpeaking = false;
+extern bool actionSpeaking;
 
 namespace FuzRoBorkNamespace {
 


### PR DESCRIPTION
## Summary
Changed `actionSpeaking` from a static variable in the header to an extern declaration with definition in .cpp file.

## Problem
`static bool actionSpeaking` in the header creates a separate copy in each translation unit. Changes made in one .cpp file wouldn't be visible to other .cpp files.

## Solution
- **Header:** `extern bool actionSpeaking;` (declaration only)
- **FuzRoBorkInternals.cpp:** `bool actionSpeaking = false;` (single definition)

## Testing
- [ ] Build succeeds (no linker errors)
- [ ] Variable is shared across translation units

Closes #5