### PR TITLE
Fix #7: Correct wrong path string from Fuz Ro Doh to Fuz Ro Bork

### DIFF
--- a/Hooks.cpp
+++ b/Hooks.cpp
@@ -107,7 +107,7 @@ void SneakAtackVoicePath(CachedResponseData* Data, char* VoicePathBuffer)
 		if (ResponseText.length() > 1 || (ResponseText.length() == 1 && ResponseText[0] == ' ' && kSkipEmptyResponses.GetData().i == 0))
 		{
 			_MESSAGE("Missing Asset");
-			FORMAT_STR(ShimAssetFilePath, "Data\\Sound\\Voice\\Fuz Ro Doh\\Stock_%d.xwm", SecondsOfSilence);
+			FORMAT_STR(ShimAssetFilePath, "Data\\Sound\\Voice\\Fuz Ro Bork\\Stock_%d.xwm", SecondsOfSilence);
 			CALL_MEMBER_FN(&Data->voiceFilePath, Set)(ShimAssetFilePath);
 			_MESSAGE("Missing Asset - Switching to '%s'", ShimAssetFilePath);
 		}


### PR DESCRIPTION
## Summary
Corrected the shim asset file path from "Fuz Ro Doh" to "Fuz Ro Bork".

## Problem
The path `Data\Sound\Voice\Fuz Ro Doh\Stock_%d.xwm` referenced the original mod name instead of the current plugin name.

## Solution
Changed to `Data\Sound\Voice\Fuz Ro Bork\Stock_%d.xwm`.

## Testing
- [ ] Build succeeds
- [ ] Silent dialogue fallback works (when voice file is missing)

Closes #7