### PR TITLE
Fix #9: Remove early return in IsRegexMatch that causes unreachable code

### DIFF
--- a/FuzRoBorkInternals.cpp
+++ b/FuzRoBorkInternals.cpp
@@ -420,17 +420,17 @@ namespace FuzRoBorkNamespace {
 	}
 
 	bool IsRegexMatch(const char* str, const char* rx) {
-		return false;
-		_MESSAGE("checking regex %s %s", str, rx);
-		try {
-			return (strlen(rx) > 0 && regex_match(str, regex(rx)));
-		}
-		catch(...)
-		{
-			_MESSAGE("regex error");
+		if (!str || !rx || strlen(rx) == 0) {
 			return false;
 		}
-		return false;
+		_MESSAGE("checking regex %s %s", str, rx);
+		try {
+			return regex_match(str, regex(rx));
+		}
+		catch (const std::regex_error& e) {
+			_MESSAGE("regex error: %s", e.what());
+			return false;
+		}
 	}
 
 	void wav_find_timer_start(std::function<bool(void)> func, unsigned int interval)


### PR DESCRIPTION
## Summary
Fixed `IsRegexMatch()` which was always returning false due to an early return statement.

## Problem
The function had `return false;` as its first line, making all regex matching code unreachable. This disabled regex-based NPC name/race pattern matching in XML configuration.

## Solution
- Removed the erroneous early `return false` statement
- Added proper null/empty input checking
- Improved exception handling to catch `std::regex_error` specifically
- Now logs actual regex error message for easier debugging
- Removed redundant final return statement

## Testing
- [ ] Build succeeds
- [ ] Regex patterns in NPC XML configuration now match correctly

Closes #9