### PR TITLE
Fix #11: Add explicit parentheses for operator precedence clarity

### DIFF
--- a/FuzRoBorkInternals.cpp
+++ b/FuzRoBorkInternals.cpp
@@ -406,7 +406,7 @@ namespace FuzRoBorkNamespace {
 			if (
 				(
 					(nName != "null" && strlen(nName) > 0 && (strcmp(NPCList[i].name, nName) == 0 || IsRegexMatch(nName, NPCList[i].name)))
-					|| (nRace != "null" && strlen(nRace) > 0 && (strcmp(NPCList[i].race, nRace) == 0 || IsRegexMatch(nRace, NPCList[i].race) && (npc.sex == -1 || npc.sex == NPCList[i].sex)))
+					|| (nRace != "null" && strlen(nRace) > 0 && (strcmp(NPCList[i].race, nRace) == 0 || (IsRegexMatch(nRace, NPCList[i].race) && (npc.sex == -1 || npc.sex == NPCList[i].sex))))
 				)
 			)
 			{


### PR DESCRIPTION
## Summary
Added explicit parentheses to clarify operator precedence in the NPC matching logic.

## Problem
The expression `strcmp(...) == 0 || IsRegexMatch(...) && (sex check)` relied on implicit operator precedence, making the logic unclear at a glance.

## Solution
Added parentheses: `strcmp(...) == 0 || (IsRegexMatch(...) && (sex check))`

This makes explicit that:
- Exact race match always succeeds
- Regex race match requires sex to also match

Behavior is unchanged - this just matches C++ operator precedence where `&&` binds tighter than `||`.

## Testing
- [ ] Build succeeds
- [ ] NPC matching behavior unchanged

Closes #11